### PR TITLE
Make Validation' fully saturated with just 1 argument.

### DIFF
--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -436,8 +436,8 @@ data ValidationT err m a =
     runValidationT :: m (Validation err a)
   }
 
-type Validation' err a =
-  ValidationT err Identity a
+type Validation' err =
+  ValidationT err Identity
 
 fmapValidationT ::
   Functor f =>


### PR DESCRIPTION
100% backward compatible; just makes it so `Validation' e` has a kind (can be passed as a type argument &c).
