### PR TITLE
Update cabal version for release

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+0.5.5
+
+* Raise upper bounds on base.
+
 0.5.4
 
 * remove redundant constraints.
@@ -50,7 +54,7 @@ A restructuring of 0.2.x where:
 
 * Tests updated to use doctest
 * Update API to use Prism and Iso (Control.Lens)
-* Rename package Validation (deprecated) to validation 
+* Rename package Validation (deprecated) to validation
 
 0.3.1
 

--- a/validation.cabal
+++ b/validation.cabal
@@ -1,5 +1,5 @@
 name:               validation
-version:            0.5.4
+version:            0.5.5
 license:            BSD3
 license-file:       LICENSE
 author:             Tony Morris <ʇǝu˙sıɹɹoɯʇ@ןןǝʞsɐɥ> <dibblego>, Nick Partridge <nkpart>
@@ -8,7 +8,7 @@ copyright:          Copyright (C) 2010-2013 Tony Morris, Nick Partridge
 copyright:          Copyright (C) 2014,2015 NICTA Limited
 synopsis:           A data-type like Either but with an accumulating Applicative
 category:           Data
-description:        
+description:
   <<http://i.imgur.com/Ns5hntl.jpg>>
   .
   Several data-types like Either but with differing properties and type-class
@@ -59,7 +59,7 @@ description:
   .
   * `Validation'`
   .
-  The `Validation' err a` type-alias is equivalent to 
+  The `Validation' err a` type-alias is equivalent to
   `ValidationT err Identity a` and so is isomorphic to `Either` and others.
   Libraries are supplied accordingly.
 


### PR DESCRIPTION
The upper bounds on base have been raised in order to build with GHC
8.2. The validation version has been bumped to account for this
broadening of bounds.

note: There are some spurious white space changes because of some aggressive editor settings.