### PR TITLE
Delete Validation and associated machinery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,36 +22,3 @@ Download from [hackage](http://hackage.haskell.org/package/validation).
   `Bind` or `Monad` instance. `AccValidation` is an example of, "An applicative
   functor that is not a monad."
 
-* `Validation`
-
-  The `Validation` data type is isomorphic to `Either` and has a `Monad`
-  instance that does the same as `Either`. The only difference to `Either` is
-  the constructor names and surrounding library support.
-
-* `ValidationT`
-
-  The `ValidationT` data type is the monad transformer for `Validation`. An
-  instance of `MonadTrans` is provided for `(ValidationT err)`. Due to the
-  arrangement of the `ValidationT` type constructor, which permits a `MonadTrans`
-  instance, there is no possible `Bifunctor` instance. Consequently, the
-  `ValidationB` data type provides a `Bifunctor` instance (but not a
-  `MonadTrans` instance). Library support is provided to exploit the isomorphism
-  to `ValidationB`.
-
-  Note that since `AccValidation` is not a monad, there is also no corresponding
-  monad transformer for this data type.
-
-* `ValidationB`
-
-  The `ValidationB` data type is similar to the monad transformer for
-  `Validation` (`ValidationT`), however, due to the arrangement of the
-  `ValidationB` type constructor, which permits a `Bifunctor` instance, there is
-  no possible `MonadTrans` instance. Consequently, the `ValidationT` data type
-  provides a `MonadTrans` instance (but not a `Bifunctor` instance). Library
-  support is provided to exploit the isomorphism to `ValidationT`.
-
-* `Validation'`
-
-  The `Validation' err a` type-alias is equivalent to 
-  `ValidationT err Identity a` and so is isomorphic to `Either` and others.
-  Libraries are supplied accordingly.

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -7,10 +7,6 @@ module Data.Validation
 (
   -- * Data types
   AccValidation(..)
-, Validation(..)
-, ValidationT(..)
-, ValidationB(..)
-, Validation'
   -- * Prisms
 , _Failure
 , _Success
@@ -18,13 +14,11 @@ module Data.Validation
 , Validate(..)
 ) where
 
-import Control.Applicative(Applicative((<*>), pure), liftA2, (<$>))
+import Control.Applicative(Applicative((<*>), pure), (<$>))
 import Control.Lens.Getter((^.))
 import Control.Lens.Iso(Swapped(..), Iso, iso)
 import Control.Lens.Prism(Prism, prism)
 import Control.Lens.Review(( # ))
-import Control.Monad(Monad((>>=), return), liftM)
-import Control.Monad.Trans.Class(MonadTrans, lift)
 import Data.Bifoldable(Bifoldable(bifoldr))
 import Data.Bifunctor(Bifunctor(bimap))
 import Data.Bitraversable(Bitraversable(bitraverse))
@@ -32,12 +26,10 @@ import Data.Data(Data)
 import Data.Either(Either(Left, Right))
 import Data.Eq(Eq)
 import Data.Foldable(Foldable(foldr))
-import Data.Function((.), id, flip)
+import Data.Function(id)
 import Data.Functor(Functor(fmap))
 import Data.Functor.Alt(Alt((<!>)))
 import Data.Functor.Apply(Apply((<.>)))
-import Data.Functor.Bind(Bind((>>-)), liftF2)
-import Data.Functor.Identity(Identity(Identity, runIdentity))
 import Data.Monoid(Monoid(mappend, mempty))
 import Data.Ord(Ord)
 import Data.Semigroup(Semigroup((<>)))
@@ -53,9 +45,6 @@ import Prelude(Show)
 -- >>> import Test.QuickCheck
 -- >>> import Data.Either(either)
 -- >>> instance (Arbitrary err, Arbitrary a) => Arbitrary (AccValidation err a) where arbitrary = fmap (either (_Failure #) (_Success #)) arbitrary
--- >>> instance (Arbitrary err, Arbitrary a) => Arbitrary (Validation err a) where arbitrary = fmap (either (_Failure #) (_Success #)) arbitrary
--- >>> instance (Applicative m, Arbitrary err, Arbitrary a) => Arbitrary (ValidationT err m a) where arbitrary = fmap (ValidationT . pure) arbitrary
--- >>> instance (Applicative m, Arbitrary err, Arbitrary a) => Arbitrary (ValidationB m err a) where arbitrary = fmap (ValidationB . pure) arbitrary
 
 -- | A value of the type @err@ or @a@, however, the @Applicative@ instance
 -- accumulates values. This is witnessed by the @Semigroup@ context on the instance.
@@ -263,557 +252,27 @@ instance Monoid e => Monoid (AccValidation e a) where
   mempty =
     emptyAccValidation
 
--- | A value of the type @err@ or @a@ and isomorphic to @Data.Either@.
---
--- >>> _Success # (+1) <*> _Success # 7 :: Validation String Int
--- Success 8
---
--- >>> _Failure # ["f1"] <*> _Success # 7 :: Validation [String] Int
--- Failure ["f1"]
---
--- >>> _Success # (+1) <*> _Failure # ["f2"] :: Validation [String] Int
--- Failure ["f2"]
---
--- >>> _Failure # ["f1"] <*> _Failure # ["f2"] :: Validation [String] Int
--- Failure ["f1"]
-data Validation err a =
-  Failure err
-  | Success a
-  deriving (Eq, Ord, Show, Data, Typeable)
-
-fmapValidation ::
-  (a -> b)
-  -> Validation err a
-  -> Validation err b
-fmapValidation _ (Failure e) =
-  Failure e
-fmapValidation f (Success a) =
-  Success (f a)
-{-# INLINE fmapValidation #-}
-
-instance Functor (Validation err) where
-  fmap =
-    fmapValidation
-
-apValidation ::
-  Validation err (a -> b)
-  -> Validation err a
-  -> Validation err b
-Failure e1 `apValidation` Failure _  =
-  Failure e1
-Failure e1 `apValidation` Success _  =
-  Failure e1
-Success _  `apValidation` Failure e2 =
-  Failure e2
-Success f  `apValidation` Success a  =
-  Success (f a)
-{-# INLINE apValidation #-}
-
-instance Apply (Validation err) where
-  (<.>) =
-    apValidation
-
-instance Applicative (Validation err) where
-  pure =
-    Success
-  (<*>) =
-    apValidation
-
-altValidation ::
-  Validation err a
-  -> Validation err a
-  -> Validation err a
-Failure _ `altValidation` x =
-  x
-Success a `altValidation` _ =
-  Success a
-{-# INLINE altValidation #-}
-
-instance Alt (Validation err) where
-  (<!>) =
-    altValidation
-
-foldrValidation ::
-  (a -> b -> b)
-  -> b
-  -> Validation err a
-  -> b
-foldrValidation f x (Success a) =
-  f a x
-foldrValidation _ x (Failure _) =
-  x
-{-# INLINE foldrValidation #-}
-
-instance Foldable (Validation err) where
-  foldr =
-    foldrValidation
-
-traverseValidation ::
-  Applicative f =>
-  (a -> f b)
-  -> Validation err a
-  -> f (Validation err b)
-traverseValidation f (Success a) =
-  Success <$> f a
-traverseValidation _ (Failure e) =
-  pure (Failure e)
-{-# INLINE traverseValidation #-}
-
-instance Traversable (Validation err) where
-  traverse =
-    traverseValidation
-
-bimapValidation ::
-  (err -> f)
-  -> (a -> b)
-  -> Validation err a
-  -> Validation f b
-bimapValidation f _ (Failure e) =
-  Failure (f e)
-bimapValidation _ g (Success a) =
-  Success (g a)
-{-# INLINE bimapValidation #-}
-
-instance Bifunctor Validation where
-  bimap =
-    bimapValidation
-
-bifoldrValidation ::
-  (x -> a -> b)
-  -> (y -> a -> b)
-  -> a
-  -> Validation x y
-  -> b
-bifoldrValidation _ g x (Success a) =
-  g a x
-bifoldrValidation f _ x (Failure e) =
-  f e x
-{-# INLINE bifoldrValidation #-}
-
-instance Bifoldable Validation where
-  bifoldr =
-    bifoldrValidation
-
-bitraverseValidation ::
-  Functor f =>
-  (x -> f err)
-  -> (y -> f a)
-  -> Validation x y
-  -> f (Validation err a)
-bitraverseValidation _ g (Success a) =
-  Success <$> g a
-bitraverseValidation f _ (Failure e) =
-  Failure <$> f e
-{-# INLINE bitraverseValidation #-}
-
-instance Bitraversable Validation where
-  bitraverse =
-    bitraverseValidation
-
-bindValidation ::
-  Validation err a
-  -> (a -> Validation err b)
-  -> Validation err b
-Failure e `bindValidation` _ =
-  Failure e
-Success a `bindValidation` f =
-  f a
-{-# INLINE bindValidation #-}
-
-instance Bind (Validation err) where
-  (>>-) =
-    bindValidation
-
-instance Monad (Validation err) where
-  return =
-    Success
-  (>>=) =
-    bindValidation
-
--- | The transformer version of @Validation@.
-data ValidationT err m a =
-  ValidationT {
-    runValidationT :: m (Validation err a)
-  }
-
-type Validation' err a =
-  ValidationT err Identity a
-
-fmapValidationT ::
-  Functor f =>
-  (a -> b)
-  -> ValidationT err f a
-  -> ValidationT err f b
-fmapValidationT f (ValidationT k) =
-  ValidationT (fmap (fmap f) k)
-{-# INLINE fmapValidationT #-}
-
-instance Functor m => Functor (ValidationT err m) where
-  fmap =
-    fmapValidationT
-
-apValidationT ::
-  Apply f =>
-  ValidationT err f (a -> b)
-  -> ValidationT err f a
-  -> ValidationT err f b
-ValidationT f `apValidationT` ValidationT a =
-    ValidationT (liftF2 (<.>) f a)
-{-# INLINE apValidationT #-}
-
-instance Apply m => Apply (ValidationT err m) where
-  (<.>) =
-    apValidationT
-
-pureValidationT ::
-  Applicative f =>
-  a
-  -> ValidationT err f a
-pureValidationT =
-  ValidationT . pure . pure
-{-# INLINE pureValidationT #-}
-
-aplValidationT ::
-  Applicative f =>
-  ValidationT err f (a -> b)
-  -> ValidationT err f a
-  -> ValidationT err f b
-ValidationT f `aplValidationT` ValidationT a =
-    ValidationT (liftA2 (<*>) f a)
-{-# INLINE aplValidationT #-}
-
-instance Applicative m => Applicative (ValidationT err m) where
-  pure =
-    pureValidationT
-  (<*>) =
-    aplValidationT
-
-altValidationT ::
-  Monad m =>
-  ValidationT err m a
-  -> ValidationT err m a
-  -> ValidationT err m a
-ValidationT x `altValidationT` ValidationT y =
-  ValidationT (x >>= \q -> case q of
-    Failure _ -> y
-    Success a -> return (Success a))
-{-# INLINE altValidationT #-}
-
-instance (Functor m, Monad m) => Alt (ValidationT err m) where
-  (<!>) =
-    altValidationT
-
-foldrValidationT ::
-  Foldable f =>
-  (a -> b -> b)
-  -> b
-  -> ValidationT err f a
-  -> b
-foldrValidationT f z (ValidationT x) =
-  foldr (flip (foldr f)) z x
-{-# INLINE foldrValidationT #-}
-
-instance Foldable m => Foldable (ValidationT err m) where
-  foldr =
-    foldrValidationT
-
-traverseValidationT ::
-  (Traversable g, Applicative f) =>
-  (a -> f b)
-  -> ValidationT err g a
-  -> f (ValidationT err g b)
-traverseValidationT f (ValidationT x) =
-  ValidationT <$> traverse (traverse f) x
-{-# INLINE traverseValidationT #-}
-
-instance Traversable m => Traversable (ValidationT err m) where
-  traverse =
-    traverseValidationT
-
-bindValidationT ::
-  Monad f =>
-  ValidationT err f a
-  -> (a -> ValidationT err f b)
-  -> ValidationT err f b
-ValidationT v `bindValidationT` f =
-  ValidationT (v >>= \w -> case w of
-                             Failure e -> return (Failure e)
-                             Success a -> runValidationT (f a))
-{-# INLINE bindValidationT #-}
-
-instance (Apply m, Monad m) => Bind (ValidationT err m) where
-  (>>-) =
-    bindValidationT
-
-returnValidationT ::
-  Monad f =>
-  a
-  -> ValidationT err f a
-returnValidationT =
-  ValidationT . return . pure
-{-# INLINE returnValidationT #-}
-
-instance Monad m => Monad (ValidationT err m) where
-  return =
-    returnValidationT
-  (>>=) =
-    bindValidationT
-
-instance MonadTrans (ValidationT err) where
-  lift = liftValidationT
-
-liftValidationT ::
-  Monad m =>
-  m a
-  -> ValidationT e m a
-liftValidationT =
-  ValidationT . liftM Success
-{-# INLINE liftValidationT #-}
-
--- | The bifunctor version of ValidationT
-data ValidationB m err a =
-  ValidationB {
-    runValidationB :: m (Validation err a)
-  }
-
-fmapValidationB ::
-  Functor f =>
-  (a -> b)
-  -> ValidationB f err a
-  -> ValidationB f err b
-fmapValidationB f (ValidationB k) =
-  ValidationB (fmap (fmap f) k)
-{-# INLINE fmapValidationB #-}
-
-instance Functor m => Functor (ValidationB m err) where
-  fmap =
-    fmapValidationB
-
-apValidationB ::
-  Apply f =>
-  ValidationB f err (a -> b)
-  -> ValidationB f err a
-  -> ValidationB f err b
-ValidationB f `apValidationB` ValidationB a =
-    ValidationB (liftF2 (<.>) f a)
-{-# INLINE apValidationB #-}
-
-instance Apply m => Apply (ValidationB m err) where
-  (<.>) =
-    apValidationB
-
-pureValidationB ::
-  Applicative f =>
-  a
-  -> ValidationB f err a
-pureValidationB =
-  ValidationB . pure . pure
-{-# INLINE pureValidationB #-}
-
-aplValidationB ::
-  Applicative f =>
-  ValidationB f err (a -> b)
-  -> ValidationB f err a
-  -> ValidationB f err b
-ValidationB f `aplValidationB` ValidationB a =
-    ValidationB (liftA2 (<*>) f a)
-{-# INLINE aplValidationB #-}
-
-instance Applicative m => Applicative (ValidationB m err) where
-  pure =
-    pureValidationB
-  (<*>) =
-    aplValidationB
-
-altValidationB ::
-  Monad m =>
-  ValidationB m err a
-  -> ValidationB m err a
-  -> ValidationB m err a
-ValidationB x `altValidationB` ValidationB y =
-  ValidationB (x >>= \q -> case q of
-    Failure _ -> y
-    Success a -> return (Success a))
-{-# INLINE altValidationB #-}
-
-instance (Functor m, Monad m) => Alt (ValidationB m err) where
-  (<!>) =
-    altValidationB
-
-foldrValidationB ::
-  Foldable f =>
-  (a -> b -> b)
-  -> b
-  -> ValidationB f err a
-  -> b
-foldrValidationB f z (ValidationB x) =
-  foldr (flip (foldr f)) z x
-{-# INLINE foldrValidationB #-}
-
-instance Foldable m => Foldable (ValidationB m err) where
-  foldr =
-    foldrValidationB
-
-traverseValidationB ::
-  (Traversable g, Applicative f) =>
-  (a -> f b)
-  -> ValidationB g err a
-  -> f (ValidationB g err b)
-traverseValidationB f (ValidationB x) =
-  ValidationB <$> traverse (traverse f) x
-{-# INLINE traverseValidationB #-}
-
-instance Traversable m => Traversable (ValidationB m err) where
-  traverse =
-    traverseValidationB
-
-bimapValidationB ::
-  Functor f =>
-  (err -> frr)
-  -> (a -> b)
-  -> ValidationB f err a
-  -> ValidationB f frr b
-bimapValidationB f g (ValidationB x) =
-  ValidationB (fmap (bimap f g) x)
-{-# INLINE bimapValidationB #-}
-
-instance Functor m => Bifunctor (ValidationB m) where
-  bimap =
-    bimapValidationB
-
-bifoldrValidationB ::
-  Foldable f =>
-  (err -> b -> b)
-  -> (a -> b -> b)
-  -> b
-  -> ValidationB f err a
-  -> b
-bifoldrValidationB f g z (ValidationB x) =
-  foldr (flip (bifoldr f g)) z x
-{-# INLINE bifoldrValidationB #-}
-
-instance Foldable m => Bifoldable (ValidationB m) where
-  bifoldr =
-    bifoldrValidationB
-
-bitraverseValidationB ::
-  (Traversable g, Applicative f) =>
-  (err -> f frr)
-  -> (a -> f b)
-  -> ValidationB g err a
-  -> f (ValidationB g frr b)
-bitraverseValidationB f g (ValidationB x) =
-  ValidationB <$> traverse (bitraverse f g) x
-{-# INLINE bitraverseValidationB #-}
-
-instance Traversable m => Bitraversable (ValidationB m) where
-  bitraverse =
-    bitraverseValidationB
-
-bindValidationB ::
-  Monad f =>
-  ValidationB f err a
-  -> (a -> ValidationB f err b)
-  -> ValidationB f err b
-ValidationB v `bindValidationB` f =
-  ValidationB (v >>= \w -> case w of
-                             Failure e -> return (Failure e)
-                             Success a -> runValidationB (f a))
-{-# INLINE bindValidationB #-}
-instance (Apply m, Monad m) => Bind (ValidationB m err) where
-  (>>-) =
-    bindValidationB
-
-returnValidationB ::
-  Monad f =>
-  a
-  -> ValidationB f err a
-returnValidationB =
-  ValidationB . return . pure
-{-# INLINE returnValidationB #-}
-
-instance Monad m => Monad (ValidationB m err) where
-  return =
-    returnValidationB
-  (>>=) =
-    bindValidationB
-
-_ValidationV' ::
-  Validate f =>
-  Iso (f e a) (f g b) (Validation' e a) (Validation' g b)
-_ValidationV' =
-  iso
-    (\x -> ValidationT (Identity (x ^. _Validation)))
-    (\(ValidationT (Identity x)) -> _Validation # x)
-{-# INLINE _ValidationV' #-}
-
-_ValidationTx ::
-  Iso (ValidationT e m a) (ValidationT e' m' a') (ValidationB m e a) (ValidationB m' e' a')
-_ValidationTx =
-  iso
-    (\(ValidationT x) -> ValidationB x)
-    (\(ValidationB x) -> ValidationT x)
-
-_AccValidationV ::
-  Validate f =>
-  Iso (f e a) (f g b) (AccValidation e a) (AccValidation g b)
-_AccValidationV =
-  iso
-    (\x -> case x ^. _Validation of
-             Failure e -> AccFailure e
-             Success a -> AccSuccess a)
-    (\x -> _Validation # case x of
-                           AccFailure e -> Failure e
-                           AccSuccess a -> Success a)
-{-# INLINE _AccValidationV #-}
-
 _EitherV ::
   Validate f =>
   Iso (f e a) (f g b) (Either e a) (Either g b)
 _EitherV =
   iso
-    (\x -> case x ^. _Validation of
-             Failure e -> Left e
-             Success a -> Right a)
-    (\x -> _Validation # case x of
-                           Left e -> Failure e
-                           Right a -> Success a)
+    (\x -> case x ^. _AccValidation of
+             AccFailure e -> Left e
+             AccSuccess a -> Right a)
+    (\x -> _AccValidation # case x of
+                           Left e -> AccFailure e
+                           Right a -> AccSuccess a)
 {-# INLINE _EitherV #-}
 
 class Validate f where
-  _Validation ::
-    Iso (f e a) (f g b) (Validation e a) (Validation g b)
-
-  _Validation' ::
-    Iso (f e a) (f g b) (Validation' e a) (Validation' g b)
-  _Validation' =
-    _ValidationV'
-
   _AccValidation ::
     Iso (f e a) (f g b) (AccValidation e a) (AccValidation g b)
-  _AccValidation =
-    _AccValidationV
 
   _Either ::
     Iso (f e a) (f g b) (Either e a) (Either g b)
   _Either =
     _EitherV
-
-instance Validate Validation where
-  _Validation =
-    id
-
-_AccValidationValidationIso ::
-  Iso (AccValidation e a) (AccValidation g b) (Validation e a) (Validation g b)
-_AccValidationValidationIso =
-  iso
-    (\x -> case x of
-             AccFailure e -> Failure e
-             AccSuccess a -> Success a)
-    (\x -> case x of
-             Failure e -> AccFailure e
-             Success a -> AccSuccess a)
-{-# INLINE _AccValidationValidationIso #-}
 
 _AccValidationEitherIso ::
   Iso (AccValidation e a) (AccValidation g b) (Either e a) (Either g b)
@@ -828,24 +287,10 @@ _AccValidationEitherIso =
 {-# INLINE _AccValidationEitherIso #-}
 
 instance Validate AccValidation where
-  _Validation =
-    _AccValidationValidationIso
   _AccValidation =
     id
   _Either =
     _AccValidationEitherIso
-
-_EitherValidationIso ::
-  Iso (Either e a) (Either g b) (Validation e a) (Validation g b)
-_EitherValidationIso =
-  iso
-    (\x -> case x of
-             Left e -> Failure e
-             Right a -> Success a)
-    (\x -> case x of
-             Failure e -> Left e
-             Success a -> Right a)
-{-# INLINE _EitherValidationIso #-}
 
 _EitherAccValidationIso ::
   Iso (Either e a) (Either g b) (AccValidation e a) (AccValidation g b)
@@ -860,18 +305,10 @@ _EitherAccValidationIso =
 {-# INLINE _EitherAccValidationIso #-}
 
 instance Validate Either where
-  _Validation =
-    _EitherValidationIso
   _AccValidation =
     _EitherAccValidationIso
   _Either =
     id
-
-instance (m ~ Identity) => Validate (ValidationB m) where
-  _Validation =
-    iso
-      (\(ValidationB x) -> runIdentity x)
-      (ValidationB . Identity)
 
 _Failure ::
   Validate f =>
@@ -907,35 +344,7 @@ swappedAccValidation =
              AccSuccess e -> AccFailure e)
 {-# INLINE swappedAccValidation #-}
 
-swappedValidation ::
-  Iso (Validation e a) (Validation f b) (Validation a e) (Validation b f)
-swappedValidation =
-  iso
-    (\v -> case v of
-             Failure e -> Success e
-             Success a -> Failure a)
-    (\v -> case v of
-             Failure a -> Success a
-             Success e -> Failure e)
-{-# INLINE swappedValidation #-}
-
-swappedValidationB ::
-  Functor k =>
-  Iso (ValidationB k e a) (ValidationB k f b) (ValidationB k a e) (ValidationB k b f)
-swappedValidationB =
-  iso
-    (\(ValidationB x) -> ValidationB (fmap (swapped # ) x))
-    (\(ValidationB x) -> ValidationB (fmap (swapped # ) x))
-{-# INLINE swappedValidationB #-}
-
 instance Swapped AccValidation where
   swapped =
     swappedAccValidation
 
-instance Swapped Validation where
-  swapped =
-    swappedValidation
-
-instance Functor f => Swapped (ValidationB f) where
-  swapped =
-    swappedValidationB

--- a/validation.cabal
+++ b/validation.cabal
@@ -12,10 +12,10 @@ category:           Data
 description:
   <<http://i.imgur.com/uZnp9ke.png>>
   .
-  Several data-types like Either but with differing properties and type-class
+  A data-type like Either but with differing properties and type-class
   instances.
   .
-  Library support is provided for those different representations, include
+  Library support is provided for this different representation, include
   `lens`-related functions for converting between each and abstracting over their
   similarities.
   .
@@ -29,40 +29,6 @@ description:
   As a consequence of this `Applicative` instance, there is no corresponding
   `Bind` or `Monad` instance. `AccValidation` is an example of, "An applicative
   functor that is not a monad."
-  .
-  * `Validation`
-  .
-  The `Validation` data type is isomorphic to `Either` and has a `Monad`
-  instance that does the same as `Either`. The only difference to `Either` is
-  the constructor names and surrounding library support.
-  .
-  * `ValidationT`
-  .
-  The `ValidationT` data type is the monad transformer for `Validation`. An
-  instance of `MonadTrans` is provided for `(ValidationT err)`. Due to the
-  arrangement of the `ValidationT` type constructor, which permits a `MonadTrans
-  instance, there is no possible `Bifunctor` instance. Consequently, the
-  `ValidationB` data type provides a `Bifunctor` instance (but not a
-  `MonadTrans` instance). Library support is provided to exploit the isomorphism
-  to `ValidationB`.
-  .
-  Note that since `AccValidation` is not a monad, there is also no corresponding
-  monad transformer for this data type.
-  .
-  * `ValidationB`
-  .
-  The `ValidationB` data type is similar to the monad transformer for
-  `Validation` (`ValidationT`), however, due to the arrangement of the
-  `ValidationB` type constructor, which permits a `Bifunctor` instance, there is
-  no possible `MonadTrans` instance. Consequently, the `ValidationT` data type
-  provides a `MonadTrans` instance (but not a `Bifunctor` instance). Library
-  support is provided to exploit the isomorphism to `ValidationT`.
-  .
-  * `Validation'`
-  .
-  The `Validation' err a` type-alias is equivalent to
-  `ValidationT err Identity a` and so is isomorphic to `Either` and others.
-  Libraries are supplied accordingly.
 
 homepage:           https://github.com/qfpl/validation
 bug-reports:        https://github.com/qfpl/validation/issues


### PR DESCRIPTION
It is deprecated by Either. AccValidation is still useful.
Closes #3 