### PR TITLE
Add more functions to construct and use AccValidation

### DIFF
--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -30,11 +30,12 @@ module Data.Validation
 , _Success
   -- * Isomorphisms
 , Validate(..)
+, revalidate
 ) where
 
 import Control.Applicative(Applicative((<*>), pure), (<$>))
 import Control.Lens.Getter((^.))
-import Control.Lens.Iso(Swapped(..), Iso, iso)
+import Control.Lens.Iso(Swapped(..), Iso, iso, from)
 import Control.Lens.Prism(Prism, prism)
 import Control.Lens.Review(( # ))
 import Data.Bifoldable(Bifoldable(bifoldr))
@@ -398,4 +399,8 @@ _Success =
              Left e -> Left (_Either # Left e)
              Right a -> Right a)
 {-# INLINE _Success #-}
+
+-- | 'revalidate' converts between any two instances of 'Validate'.
+revalidate :: (Validate f, Validate g) => Iso (f e1 s) (f e2 t) (g e1 s) (g e2 t)
+revalidate = _AccValidation . from _AccValidation
 

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -18,7 +18,7 @@ module Data.Validation
 , orElse
 , valueOr
 , ensure
-, diagonal
+, codiagonal
   -- * Prisms
   -- | These prisms are useful for writing code which is polymorphic in its
   -- choice of Either or AccValidation. This choice can then be made later by a
@@ -319,9 +319,9 @@ valueOr ea v = case v of
   AccFailure e -> ea e
   AccSuccess a -> a
 
--- | 'diagonal' gets the value out of either side.
-diagonal :: AccValidation a a -> a
-diagonal = valueOr id
+-- | 'codiagonal' gets the value out of either side.
+codiagonal :: AccValidation a a -> a
+codiagonal = valueOr id
 
 -- | 'ensure' leaves the validation unchanged when the predicate holds, or
 -- fails with @e@ otherwise.

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -11,7 +11,7 @@ module Data.Validation
 , validate
 , validationNel
 , fromEither
-, translateErrors
+, liftError
   -- * Functions on validations
 , validation
 , toEither
@@ -283,19 +283,19 @@ validate :: e -> (a -> Bool) -> a -> AccValidation e a
 validate e p a =
   if p a then AccSuccess a else AccFailure e
 
--- | 'validationNel' is 'translateErrors' specialised to 'NonEmpty' lists, since
+-- | 'validationNel' is 'liftError' specialised to 'NonEmpty' lists, since
 -- they are a common semigroup to use.
 validationNel :: Either e a -> AccValidation (NonEmpty e) a
-validationNel = translateErrors pure
+validationNel = liftError pure
 
 -- | Converts from 'Either' to 'AccValidation'.
 fromEither :: Either e a -> AccValidation e a
-fromEither = translateErrors id
+fromEither = liftError id
 
--- | 'translateErrors' is useful for converting an 'Either' to an 'AccValidation'
+-- | 'liftError' is useful for converting an 'Either' to an 'AccValidation'
 -- when the @Left@ of the 'Either' needs to be lifted into a 'Semigroup'.
-translateErrors :: (b -> e) -> Either b a -> AccValidation e a
-translateErrors f = either (AccFailure . f) AccSuccess
+liftError :: (b -> e) -> Either b a -> AccValidation e a
+liftError f = either (AccFailure . f) AccSuccess
 
 -- | 'validation' is the catamorphism for @AccValidation@.
 validation :: (e -> c) -> (a -> c) -> AccValidation e a -> c

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -34,6 +34,7 @@ module Data.Validation
 ) where
 
 import Control.Applicative(Applicative((<*>), pure), (<$>))
+import Control.Lens (over)
 import Control.Lens.Getter((^.))
 import Control.Lens.Iso(Swapped(..), Iso, iso, from)
 import Control.Lens.Prism(Prism, prism)
@@ -46,7 +47,7 @@ import Data.Data(Data)
 import Data.Either(Either(Left, Right), either)
 import Data.Eq(Eq)
 import Data.Foldable(Foldable(foldr))
-import Data.Function(id, (.))
+import Data.Function((.), ($), id)
 import Data.Functor(Functor(fmap))
 import Data.Functor.Alt(Alt((<!>)))
 import Data.Functor.Apply(Apply((<.>)))
@@ -280,9 +281,15 @@ instance Swapped AccValidation where
     swappedAccValidation
 
 -- | 'validate's the @a@ with the given predicate, returning @e@ if the predicate does not hold.
-validate :: e -> (a -> Bool) -> a -> AccValidation e a
+--
+-- This can be thought of as having the less general type:
+--
+-- @
+-- validate :: e -> (a -> Bool) -> a -> AccValidation e a
+-- @
+validate :: Validate v => e -> (a -> Bool) -> a -> v e a
 validate e p a =
-  if p a then AccSuccess a else AccFailure e
+  if p a then _Success # a else _Failure # e
 
 -- | 'validationNel' is 'liftError' specialised to 'NonEmpty' lists, since
 -- they are a common semigroup to use.
@@ -309,14 +316,26 @@ toEither :: AccValidation e a -> Either e a
 toEither = validation Left Right
 
 -- | @v 'orElse' a@ returns @a@ when @v@ is AccFailure, and the @a@ in @AccSuccess a@.
-orElse :: AccValidation e a -> a -> a
-orElse v a = case v of
+--
+-- This can be thought of as having the less general type:
+--
+-- @
+-- orElse :: AccValidation e a -> a -> a
+-- @
+orElse :: Validate v => v e a -> a -> a
+orElse v a = case v ^. _AccValidation of
   AccFailure _ -> a
   AccSuccess x -> x
 
 -- | Return the @a@ or run the given function over the @e@.
-valueOr :: (e -> a) -> AccValidation e a -> a
-valueOr ea v = case v of
+--
+-- This can be thought of as having the less general type:
+--
+-- @
+-- valueOr :: (e -> a) -> AccValidation e a -> a
+-- @
+valueOr :: Validate v => (e -> a) -> v e a -> a
+valueOr ea v = case v ^. _AccValidation of
   AccFailure e -> ea e
   AccSuccess a -> a
 
@@ -326,15 +345,20 @@ codiagonal = valueOr id
 
 -- | 'ensure' leaves the validation unchanged when the predicate holds, or
 -- fails with @e@ otherwise.
-ensure :: e -> (a -> Bool) -> AccValidation e a -> AccValidation e a
-ensure e p v = case v of
-  AccFailure x -> AccFailure x
-  AccSuccess a -> validate e p a
+--
+-- This can be thought of as having the less general type:
+--
+-- @
+-- ensure :: e -> (a -> Bool) -> AccValidation e a -> AccValidation e a
+-- @
+ensure :: Validate v => e -> (a -> Bool) -> v e a -> v e a
+ensure e p =
+  over _AccValidation $ \v -> case v of
+    AccFailure x -> AccFailure x
+    AccSuccess a -> validate e p a
 
 -- | The @Validate@ class carries around witnesses that the type @f@ is isomorphic
 -- to AccValidation, and hence isomorphic to Either.
---
--- Its main use is to make '_Success' and '_Failure' work.
 class Validate f where
   _AccValidation ::
     Iso (f e a) (f g b) (AccValidation e a) (AccValidation g b)

--- a/test/hunit.hs
+++ b/test/hunit.hs
@@ -1,43 +1,126 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
 import Test.HUnit
 
+import Prelude hiding (length)
 import Control.Lens ((#))
-import Data.Validation (AccValidation (AccSuccess, AccFailure), _Failure, _Success)
+import Data.Foldable (length)
+import Data.Proxy (Proxy (Proxy))
+import Data.Validation (AccValidation (AccSuccess, AccFailure), Validate, _Failure, _Success, ensure,
+                        orElse, validate, validation, validationNel)
 
 seven :: Int
 seven = 7
 
-test1 :: Test
-test1 =
+three :: Int
+three = 3
+
+testYY :: Test
+testYY =
   let subject  = _Success # (+1) <*> _Success # seven :: AccValidation String Int
       expected = AccSuccess 8
   in  TestCase (assertEqual "Success <*> Success" subject expected)
 
-test2 :: Test
-test2 =
+testNY :: Test
+testNY =
   let subject  = _Failure # ["f1"] <*> _Success # seven :: AccValidation [String] Int
       expected = AccFailure ["f1"]
   in  TestCase (assertEqual "Failure <*> Success" subject expected)
 
-test3 :: Test
-test3 =
+testYN :: Test
+testYN =
   let subject  = _Success # (+1) <*> _Failure # ["f2"] :: AccValidation [String] Int
       expected = AccFailure ["f2"]
   in  TestCase (assertEqual "Success <*> Failure" subject expected)
 
-test4 :: Test
-test4 =
+testNN :: Test
+testNN =
   let subject  = _Failure # ["f1"] <*> _Failure # ["f2"] :: AccValidation [String] Int
       expected = AccFailure ["f1","f2"]
   in  TestCase (assertEqual "Failure <*> Failure" subject expected)
 
+testValidationNel :: Test
+testValidationNel =
+  let subject  = validation length (const 0) $ validationNel (Left ())
+  in  TestCase (assertEqual "validationNel makes lists of length 1" subject 1)
+
+testEnsureLeftFalse, testEnsureLeftTrue, testEnsureRightFalse, testEnsureRightTrue,
+  testOrElseRight, testOrElseLeft
+  :: forall v. (Validate v, Eq (v Int Int), Show (v Int Int)) => Proxy v -> Test
+
+testEnsureLeftFalse _ =
+  let subject :: v Int Int
+      subject = ensure three (const False) (_Failure # seven)
+  in  TestCase (assertEqual "ensure Left False" subject (_Failure # seven))
+
+testEnsureLeftTrue _ =
+  let subject :: v Int Int
+      subject = ensure three (const True) (_Failure # seven)
+  in  TestCase (assertEqual "ensure Left True" subject (_Failure # seven))
+
+testEnsureRightFalse _ =
+  let subject :: v Int Int
+      subject = ensure three (const False) (_Success # seven)
+  in  TestCase (assertEqual "ensure Right False" subject (_Failure # three))
+
+testEnsureRightTrue _ =
+  let subject :: v Int Int
+      subject = ensure three (const True ) (_Success # seven)
+  in  TestCase (assertEqual "ensure Right True" subject (_Success # seven))
+
+testOrElseRight _ =
+  let v :: v Int Int
+      v = _Success # seven
+      subject = v `orElse` three
+  in  TestCase (assertEqual "orElseRight" subject seven)
+
+testOrElseLeft _ =
+  let v :: v Int Int
+      v = _Failure # seven
+      subject = v `orElse` three
+  in  TestCase (assertEqual "orElseLeft" subject three)
+
+testValidateTrue :: Test
+testValidateTrue =
+  let subject = validate three (const True) seven
+      expected = AccSuccess seven
+  in  TestCase (assertEqual "testValidateTrue" subject expected)
+
+testValidateFalse :: Test
+testValidateFalse =
+  let subject = validate three (const True) seven
+      expected = AccFailure three
+  in  TestCase (assertEqual "testValidateFalse" subject expected)
+
 tests :: Test
 tests =
-  TestList [
-    test1
-  , test2
-  , test3
-  , test4
-  ]
+  let eitherP :: Proxy Either
+      eitherP = Proxy
+      validationP :: Proxy AccValidation
+      validationP = Proxy
+      generals :: forall v. (Validate v, Eq (v Int Int), Show (v Int Int)) => [Proxy v -> Test]
+      generals =
+        [ testEnsureLeftFalse
+        , testEnsureLeftTrue
+        , testEnsureRightFalse
+        , testEnsureRightTrue
+        , testOrElseLeft
+        , testOrElseRight
+        ]
+      eithers = fmap ($ eitherP) generals
+      validations = fmap ($ validationP) generals
+  in  TestList $ [
+    testYY
+  , testYN
+  , testNY
+  , testNN
+  , testValidationNel
+  , testValidateFalse
+  , testValidateTrue
+  ] ++ eithers ++ validations
+  where
 
 main :: IO Counts
 main = runTestTT tests


### PR DESCRIPTION
Add a bunch of functions to build and consume `AccValidation`.

I'd like feedback on parameter order and names. In particular I'm not happy with the name of `transformErrors`.