### PR TITLE
Add haddocks to `Alt` instance

### DIFF
--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -114,6 +114,7 @@ instance Semigroup err => Applicative (Validation err) where
   (<*>) =
     (<.>)
 
+-- | For two errors, this instance reports only the last of them.
 instance Alt (Validation err) where
   Failure _ <!> x =
     x


### PR DESCRIPTION
This is mainly to make the difference to the `either` package
clear, which has different behaviour.