### PR TITLE
Update Haskell Setup CI Action & GHC/Dependency Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: haskell/actions/setup@v1.1.5
+    - uses: haskell/actions/setup@v2
     - run: |
         curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s examples/src src -j
 
@@ -36,11 +36,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: haskell/actions/setup@v1.1.5
+      - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
           cabal-version: latest
-          ghc-version:   7.10.3
+          ghc-version:   8.4.4
 
       - run: cabal update
       - run: cabal clean
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: haskell/actions/setup@v1.1.5
+      - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
           cabal-version: latest
@@ -93,14 +93,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc:   [ '7.10.3', '8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.4', '9.0.1' ]
+        ghc:   [ '8.4.4', '8.6.5', '8.8.4', '8.10.4', '9.0.1' ]
         cabal: [ latest ]
         os:    [ ubuntu-latest ]
 
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Setup Haskell
-        uses: haskell/actions/setup@v1.1.5
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
         with:
           ghc-version:   ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}

--- a/lower-bounds.project
+++ b/lower-bounds.project
@@ -1,17 +1,17 @@
 constraints:
   assoc         ==1.0.*,
-  base          ==4.8.*,
+  base          ==4.11.*,
   bifunctors    ==5.5.*,
   deepseq       ==1.4.*,
-  ghc-prim      ==0.4.0.*,
+  ghc-prim      ==0.5.*,
   hedgehog      ==0.5.*,
-  HUnit         ==1.5.*,
+  HUnit         ==1.6.*,
   lens          ==4.*,
   semigroupoids ==5.*,
-  semigroups    ==0.16.*
+  semigroups    ==0.18.*
 
 packages:
   ./
   examples/
 
-with-compiler: ghc-7.10.3
+with-compiler: ghc-8.4.4

--- a/validation.cabal
+++ b/validation.cabal
@@ -46,13 +46,13 @@ library
                     Haskell2010
 
   build-depends:
-                      base          >= 4.11 && < 5
-                    , assoc         >= 1    && < 2
-                    , deepseq       >= 1.4  && < 1.5
-                    , semigroups    >= 0.16 && < 1
-                    , semigroupoids >= 5    && < 7
-                    , bifunctors    >= 5.5  && < 6
-                    , lens          >= 4    && < 6
+                      base          >= 4.11   && < 5
+                    , assoc         >= 1      && < 2
+                    , deepseq       >= 1.4.3  && < 1.5
+                    , semigroups    >= 0.18.2 && < 1
+                    , semigroupoids >= 5.2.2  && < 7
+                    , bifunctors    >= 5.5    && < 6
+                    , lens          >= 4.0.5  && < 6
 
   ghc-options:
                     -Wall
@@ -74,9 +74,9 @@ test-suite hedgehog
                     Haskell2010
 
   build-depends:
-                      base       >= 4.11 && < 5
-                    , hedgehog   >= 0.5  && < 2
-                    , semigroups >= 0.16 && < 1
+                      base       >= 4.11   && < 5
+                    , hedgehog   >= 0.5    && < 2
+                    , semigroups >= 0.18.2 && < 1
                     , validation
 
   ghc-options:
@@ -97,10 +97,10 @@ test-suite hunit
                     Haskell2010
 
   build-depends:
-                      base       >= 4.11  && < 5
-                    , HUnit      >= 1.5  && < 1.7
-                    , lens       >= 4    && < 6
-                    , semigroups >= 0.16 && < 1
+                      base       >= 4.11   && < 5
+                    , HUnit      >= 1.6    && < 1.7
+                    , lens       >= 4.0.5  && < 6
+                    , semigroups >= 0.18.2 && < 1
                     , validation
 
   ghc-options:


### PR DESCRIPTION
Bump the `haskell/actions/setup` CI action to v2.

Drop the unsupported versions of GHC from the cabal-matrix CI job.

Update the `validation.cabal` & `lower-bounds.project` files to adjust the lower bounds of dependencies to the lowest supported versions of GHC & `base`.

See valid run here: https://github.com/costarastrology/validation/actions/runs/5015856401

Would love if we can make a new release after this so we can bring this back into stackage nightly :pray: 